### PR TITLE
Add Parked Option to Charge Station

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,7 +299,7 @@
         <select name="Charge Station" id="climb">
           <option value="Select Option" selected>Select Option</option>
           <option value="NA">Not Attempted</option>
-          <option value="F">Attempted but Failed</option>
+          <option value="P">Parked</option>
           <option value="D">Docked but not Engaged</option>
           <option value="E">Engaged and Docked</option>
         </select>


### PR DESCRIPTION
We need a parked option for score tracking, and it makes sense to remove the Failed option while adding this since there are robots that fail but still park, and park but do not attempt charge. Also, there isn't any reasonable metric where keeping track of charge station fails is useful. Validation filters it out as well anyways.

Making PR cuz no one else is fixing :(