### PR TITLE
Add average calculations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea/*

--- a/src/ContextProvider.tsx
+++ b/src/ContextProvider.tsx
@@ -55,7 +55,7 @@ export enum Boolean {
 }
 
 type PreMatch = {
-  Team: String;
+  Team: string;
   NoShow: boolean;
   Match: number | undefined;
   Playoffs: boolean;


### PR DESCRIPTION
**Summary**: add an average table and then compute averages upon sending data. This allows for much faster data lookup on the average graphs.

**Changes**:
- add supabase Average table
- add query to fetch averages from team at event
- add row to table if query is null